### PR TITLE
Launching Phantom on modern qemu / on systems with grub2

### DIFF
--- a/oldtree/kernel/phantom/multiboot.c
+++ b/oldtree/kernel/phantom/multiboot.c
@@ -270,7 +270,7 @@ static void make_mem_map(void)
                 char *s = (char*)phystokv(m[i].string);
                 unsigned len = strlen(s);
 
-                SET_MEM(m[i].string, len, MEM_MAP_MOD_NAME);
+                if (len != 0) SET_MEM(m[i].string, len, MEM_MAP_MOD_NAME);
             }
 
             SET_MEM(m[i].mod_start, m[i].mod_end-m[i].mod_start, MEM_MAP_MODULE );

--- a/run/phantom_clean_new.sh
+++ b/run/phantom_clean_new.sh
@@ -1,0 +1,2 @@
+./zero_ph_img.sh
+./phantom_new.sh

--- a/run/phantom_new.sh
+++ b/run/phantom_new.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Test modern script for Phantom OS with grub2
+# Requires QEMU 2.5 or higher
+
+Q_BOOT="-boot order=d,menu=on "
+# Q_FLOPPY="-drive file=img/mygrubfloppy.img,format=raw,index=0,if=floppy "
+Q_CD="-cdrom img/grub2.iso "
+Q_DISK_A="-drive file=fat:rw:fat,format=raw,media=disk "
+Q_DISK_B="-drive file=phantom.img,format=raw,media=disk "
+# Q_NET="-net nic,model=pcnet -net nic,model=rtl8139 -net user,tftp=tftp "
+# Q_PORTS=" -serial file:serial0.log"
+Q_PORTS="-serial stdio "
+Q_DEBUG="-gdb tcp::1234 "
+# Q_KVM="--enable-kvm"
+# VIO="-drive file=vio.img,if=virtio,format=raw -net nic,model=virtio"
+
+# rm serial0.log.old1
+# mv serial0.log.old serial0.log.old1
+# mv serial0.log serial0.log.old
+
+qemu-system-i386 $Q_KVM $Q_DEBUG -display sdl -m 256M $Q_PORTS $Q_BOOT $Q_FLOPPY $Q_CD $Q_DISK_A $Q_DISK_B $Q_NET $VIO
+
+exit


### PR DESCRIPTION
This commit contains:
1. multiboot.c patch - avoid problems when running from grub2
2. New shell script to run system using qemu 2.5 and older, with grub2
3. grub2 image with all menu items ported from older grub

(I don't know how to create pull requests without making fork, if anyone knows how to create one without being part of repository - please teach me)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dzavalishin/phantomuserland/407)
<!-- Reviewable:end -->
