### PR TITLE
Update broken external link

### DIFF
--- a/include/netinet/tftp.h
+++ b/include/netinet/tftp.h
@@ -2,7 +2,7 @@
 /*
 
 THE TFTP PROTOCOL (REVISION 2)
-http://spectral.mscs.mu.edu/RFC/rfc1350.html
+https://tools.ietf.org/html/rfc1350
 
   TFTP supports five types of packets, all of which have been mentioned
    above:


### PR DESCRIPTION
Updated a broken link reference that was moved from
  http://spectral.mscs.mu.edu/RFC/rfc1350.html
to 
  https://tools.ietf.org/html/rfc1350

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dzavalishin/phantomuserland/468)
<!-- Reviewable:end -->
